### PR TITLE
Change version of handlebars dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   ],
   "dependencies": {
-    "handlebars": ">= 1.0.5beta"
+    "handlebars": "~1.3.0"
   },
   "devDependencies": {
     "connect": "*",


### PR DESCRIPTION
Force handlebars to use a version ~1.3.x instead of the newer 2.0.x alpha, until the new version will stop breaking the middleware.
