### PR TITLE
Fixing middleware capability to be used more than once.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -14,4 +14,4 @@
 
 ## 3.0.2
 
-* Fixing middleware capability to be used more that once
+* Fixing middleware capability to be used more than once

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,3 +11,7 @@
 ## 3.0.1
 
 * hbs added to default extensions
+
+## 3.0.2
+
+* Fixing middleware capability to be used more that once

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -10,14 +10,15 @@ var lib = {
         knownHelpers: [] // TODO implement this
     },
     generateTemplateRegExp: function(exts) {
-        var exts_re;
+        var prefixed_exts = [],
+            exts_re;
         if ( typeof exts == 'string' ) {
           exts_re = new RegExp("\\." + exts + "$");
         } else if ( typeof exts == 'object' && exts.length !== undefined ) {
           for(var i = 0; i < exts.length; i++) {
-            exts[i] = "." + exts[i];
+            prefixed_exts[i] = "." + exts[i];
           }
-          exts_re = new RegExp("\\" + exts.join("|") + "$");
+          exts_re = new RegExp("\\" + prefixed_exts.join("|") + "$");
         } else {
             throw new Error('Connect-Handlebars option exts only accepts string or array object');
         }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "name": "connect-handlebars",
   "description": "Connect middleware for Handlebars",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/interlock/connect-handlebars.git"


### PR DESCRIPTION
By not mutating extensions on regexp generation. Using a temp array instead.